### PR TITLE
disable source address validation

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"net"
 
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -19,6 +20,10 @@ var quicConfig = &quic.Config{
 	MaxReceiveStreamFlowControlWindow:     3 * (1 << 20),   // 3 MB
 	MaxReceiveConnectionFlowControlWindow: 4.5 * (1 << 20), // 4.5 MB
 	Versions: []quic.VersionNumber{101},
+	AcceptCookie: func(clientAddr net.Addr, cookie *quic.Cookie) bool {
+		// TODO(#6): require source address validation when under load
+		return true
+	},
 }
 
 var quicDialAddr = quic.DialAddr


### PR DESCRIPTION
The certificate chain used for the handshake is relatively small (it fits in 2 packets). This reduces the risk that an attacker will use libp2p nodes for reflection attacks.

At some point, we should require source address validation when under load (#6).