### PR TITLE
use multiaddr.Encapsulate to create QUIC multiaddrs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -82,15 +82,14 @@ func (c *conn) Transport() tpt.Transport {
 	return c.transport
 }
 
-// TODO: there must be a better way to do this
 func quicMultiaddr(na net.Addr) (ma.Multiaddr, error) {
 	udpMA, err := manet.FromNetAddr(na)
 	if err != nil {
 		return nil, err
 	}
-	quicMA, err := ma.NewMultiaddr(udpMA.String() + "/quic")
+	quicMA, err := ma.NewMultiaddr("/quic")
 	if err != nil {
 		return nil, err
 	}
-	return quicMA, nil
+	return udpMA.Encapsulate(quicMA), nil
 }


### PR DESCRIPTION
I'm not entirely sure if this is the right way to do this. This function is used in https://github.com/libp2p/go-libp2p-quic-transport/blob/multiaddr-encapsulate/transport.go#L89, https://github.com/libp2p/go-libp2p-quic-transport/blob/multiaddr-encapsulate/listener.go#L38 and https://github.com/libp2p/go-libp2p-quic-transport/blob/multiaddr-encapsulate/listener.go#L76.

For #15, we'll also need the inverse of this function, i.e. getting a `net.Addr` from a `Multiaddr`. `manet.ToNetAddr` doesn't help in this case, since QUIC doesn't fit the definition of a thin waist protocol (should it?).