### PR TITLE
use a single packet conn for all outgoing connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,15 +1,12 @@
 package libp2pquic
 
 import (
-	"net"
-
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	tpt "github.com/libp2p/go-libp2p-transport"
 	smux "github.com/libp2p/go-stream-muxer"
 	quic "github.com/lucas-clemente/quic-go"
 	ma "github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr-net"
 )
 
 type conn struct {
@@ -80,16 +77,4 @@ func (c *conn) RemoteMultiaddr() ma.Multiaddr {
 
 func (c *conn) Transport() tpt.Transport {
 	return c.transport
-}
-
-func quicMultiaddr(na net.Addr) (ma.Multiaddr, error) {
-	udpMA, err := manet.FromNetAddr(na)
-	if err != nil {
-		return nil, err
-	}
-	quicMA, err := ma.NewMultiaddr("/quic")
-	if err != nil {
-		return nil, err
-	}
-	return udpMA.Encapsulate(quicMA), nil
 }

--- a/listener.go
+++ b/listener.go
@@ -35,7 +35,7 @@ func newListener(addr ma.Multiaddr, transport tpt.Transport, localPeer peer.ID, 
 	if err != nil {
 		return nil, err
 	}
-	localMultiaddr, err := quicMultiaddr(ln.Addr())
+	localMultiaddr, err := toQuicMultiaddr(ln.Addr())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (l *listener) setupConn(sess quic.Session) (tpt.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	remoteMultiaddr, err := quicMultiaddr(sess.RemoteAddr())
+	remoteMultiaddr, err := toQuicMultiaddr(sess.RemoteAddr())
 	if err != nil {
 		return nil, err
 	}

--- a/quic_multiaddr.go
+++ b/quic_multiaddr.go
@@ -1,0 +1,30 @@
+package libp2pquic
+
+import (
+	"net"
+
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr-net"
+)
+
+var quicMA ma.Multiaddr
+
+func init() {
+	var err error
+	quicMA, err = ma.NewMultiaddr("/quic")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func toQuicMultiaddr(na net.Addr) (ma.Multiaddr, error) {
+	udpMA, err := manet.FromNetAddr(na)
+	if err != nil {
+		return nil, err
+	}
+	return udpMA.Encapsulate(quicMA), nil
+}
+
+func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, error) {
+	return manet.ToNetAddr(addr.Decapsulate(quicMA))
+}

--- a/quic_multiaddr_test.go
+++ b/quic_multiaddr_test.go
@@ -1,0 +1,30 @@
+package libp2pquic
+
+import (
+	"net"
+
+	ma "github.com/multiformats/go-multiaddr"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QUIC Multiaddr", func() {
+	It("converts a net.Addr to a QUIC Multiaddr", func() {
+		addr := &net.UDPAddr{IP: net.IPv4(192, 168, 0, 42), Port: 1337}
+		maddr, err := toQuicMultiaddr(addr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maddr.String()).To(Equal("/ip4/192.168.0.42/udp/1337/quic"))
+	})
+
+	It("converts a QUIC Multiaddr to a net.Addr", func() {
+		maddr, err := ma.NewMultiaddr("/ip4/192.168.0.42/udp/1337/quic")
+		Expect(err).ToNot(HaveOccurred())
+		addr, err := fromQuicMultiaddr(maddr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(addr).To(BeAssignableToTypeOf(&net.UDPAddr{}))
+		udpAddr := addr.(*net.UDPAddr)
+		Expect(udpAddr.IP).To(Equal(net.IPv4(192, 168, 0, 42)))
+		Expect(udpAddr.Port).To(Equal(1337))
+	})
+})

--- a/transport.go
+++ b/transport.go
@@ -86,7 +86,7 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 	if err != nil {
 		return nil, err
 	}
-	localMultiaddr, err := quicMultiaddr(sess.LocalAddr())
+	localMultiaddr, err := toQuicMultiaddr(sess.LocalAddr())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #15.

I recently merged https://github.com/lucas-clemente/quic-go/pull/1407 in quic-go, which allows running multiple dialers on the same packet conn. We can already use that in libp2p.

Note that quic-go can't *yet* run listeners and dialers on the same packet conn. I'm working on that.