### PR TITLE
allow 1000 bidirectional streams, disable unidirectional streams

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -19,6 +19,8 @@ import (
 )
 
 var quicConfig = &quic.Config{
+	MaxIncomingStreams:                    1000,
+	MaxIncomingUniStreams:                 -1,              // disable unidirectional streams
 	MaxReceiveStreamFlowControlWindow:     3 * (1 << 20),   // 3 MB
 	MaxReceiveConnectionFlowControlWindow: 4.5 * (1 << 20), // 4.5 MB
 	Versions: []quic.VersionNumber{101},


### PR DESCRIPTION
This PR increases the number of allowed incoming *concurrent* (bidirectional) streams from 100 to 1000. It also disables unidirectional streams, since we don't use those in libp2p anyway.