### PR TITLE
update to the latest quic-go, gx publish

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.0: QmTdsv6AXU5LPLMiv369ga8sgp1wMpbkmZo4scAfgnqGRZ
+0.2.0: QmVLaCVfWgjgtrAZsjk44nYG8GApxACymbsScmZJqVHMT1

--- a/conn.go
+++ b/conn.go
@@ -25,7 +25,7 @@ type conn struct {
 var _ tpt.Conn = &conn{}
 
 func (c *conn) Close() error {
-	return c.sess.Close(nil)
+	return c.sess.Close()
 }
 
 // IsClosed returns whether a connection is fully closed.

--- a/listener.go
+++ b/listener.go
@@ -65,7 +65,7 @@ func (l *listener) Accept() (tpt.Conn, error) {
 		}
 		conn, err := l.setupConn(sess)
 		if err != nil {
-			sess.Close(err)
+			sess.CloseWithError(0, err)
 			continue
 		}
 		return conn, nil

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW5LxJm2Yo3S7uVsfLM7NsJn2QnKbvZD7uYsZVYR7YViE",
+      "hash": "QmUMTtHxeyVJPrpcpvEQppH3uTf3g1NnkRC6C36LpXy2no",
       "name": "go-libp2p-transport",
-      "version": "3.0.5"
+      "version": "3.0.6"
     }
   ],
   "gxVersion": "0.11.0",
@@ -25,6 +25,6 @@
   "license": "",
   "name": "go-libp2p-quic-transport",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "marten-seemann",
-      "hash": "QmPL1Q7edxM6bHUy7rNjo6izmVte7fSbii64kr21wqmoZ2",
+      "hash": "QmaC1ix7g4NP7eduKToNN3CwpzBsmoyBR4D7FwfmXCRHxt",
       "name": "quic-go",
-      "version": "0.8.0"
+      "version": "0.9.0"
     },
     {
       "author": "whyrusleeping",

--- a/transport.go
+++ b/transport.go
@@ -19,11 +19,11 @@ import (
 )
 
 var quicConfig = &quic.Config{
+	Versions:                              []quic.VersionNumber{quic.VersionMilestone0_9_0},
 	MaxIncomingStreams:                    1000,
 	MaxIncomingUniStreams:                 -1,              // disable unidirectional streams
 	MaxReceiveStreamFlowControlWindow:     3 * (1 << 20),   // 3 MB
 	MaxReceiveConnectionFlowControlWindow: 4.5 * (1 << 20), // 4.5 MB
-	Versions: []quic.VersionNumber{101},
 	AcceptCookie: func(clientAddr net.Addr, cookie *quic.Cookie) bool {
 		// TODO(#6): require source address validation when under load
 		return true


### PR DESCRIPTION
This is the version that's supposed to go into the next go-ipfs release.