### PR TITLE
Export Conn.Context()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,8 @@
 package libp2pquic
 
 import (
+	"context"
+
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	tpt "github.com/libp2p/go-libp2p-transport"
@@ -26,6 +28,10 @@ var _ tpt.Conn = &conn{}
 
 func (c *conn) Close() error {
 	return c.sess.Close()
+}
+
+func (c *conn) Context() context.Context {
+	return c.sess.Context()
 }
 
 // IsClosed returns whether a connection is fully closed.


### PR DESCRIPTION
I find myself needing to do cleanup logic when connections are closed.  When using https://github.com/lucas-clemente/quic-go, this is easily doable using the exported `Context()` methods on `quic.Stream` and `quic.Session`.

This change does **not** change the public api, but allows users to recover the `Context()` methods using type assertions, e.g.:

```go
type Contexter interface{
    Context() context.Context
}

// ... 
cx := someLibp2pConn.(Contexter).Context()

// ... 
```

See also https://github.com/libp2p/go-libp2p-net/issues/32 & https://github.com/libp2p/go-libp2p-net/issues/33