### PR TITLE
Fixed building

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,8 @@
 package libp2pquic
 
 import (
+	"context"
+
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -36,13 +38,13 @@ func (c *conn) IsClosed() bool {
 
 // OpenStream creates a new stream.
 func (c *conn) OpenStream() (mux.MuxedStream, error) {
-	qstr, err := c.sess.OpenStreamSync()
+	qstr, err := c.sess.OpenStreamSync(context.Background())
 	return &stream{Stream: qstr}, err
 }
 
 // AcceptStream accepts a stream opened by the other side.
 func (c *conn) AcceptStream() (mux.MuxedStream, error) {
-	qstr, err := c.sess.AcceptStream()
+	qstr, err := c.sess.AcceptStream(context.Background())
 	return &stream{Stream: qstr}, err
 }
 

--- a/listener.go
+++ b/listener.go
@@ -1,6 +1,7 @@
 package libp2pquic
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 
@@ -60,13 +61,13 @@ func newListener(addr ma.Multiaddr, transport tpt.Transport, localPeer peer.ID, 
 // Accept accepts new connections.
 func (l *listener) Accept() (tpt.CapableConn, error) {
 	for {
-		sess, err := l.quicListener.Accept()
+		sess, err := l.quicListener.Accept(context.Background())
 		if err != nil {
 			return nil, err
 		}
 		conn, err := l.setupConn(sess)
 		if err != nil {
-			sess.CloseWithError(0, err)
+			sess.CloseWithError(0, err.Error())
 			continue
 		}
 		return conn, nil

--- a/transport.go
+++ b/transport.go
@@ -24,7 +24,7 @@ var quicConfig = &quic.Config{
 	MaxIncomingUniStreams:                 -1,              // disable unidirectional streams
 	MaxReceiveStreamFlowControlWindow:     3 * (1 << 20),   // 3 MB
 	MaxReceiveConnectionFlowControlWindow: 4.5 * (1 << 20), // 4.5 MB
-	AcceptCookie: func(clientAddr net.Addr, cookie *quic.Cookie) bool {
+	AcceptToken: func(clientAddr net.Addr, token *quic.Token) bool {
 		// TODO(#6): require source address validation when under load
 		return true
 	},


### PR DESCRIPTION
github.com/lucas-clemente/quic-go broke an API:
* OpenStreamSync, AcceptStream, Accept now requires context.Context
* CloseWithError now requies string (not error)
* AcceptCookie was renamed to AcceptToken

```
 ../../libp2p/go-libp2p-quic-transport/conn.go:39:36: not enough arguments in call to c.sess.OpenStreamSync
         have ()
         want (context.Context)
 ../../libp2p/go-libp2p-quic-transport/conn.go:45:34: not enough arguments in call to c.sess.AcceptStream
         have ()
         want (context.Context)
 ../../libp2p/go-libp2p-quic-transport/listener.go:63:37: not enough arguments in call to l.quicListener.Accept
         have ()
         want (context.Context)
 ../../libp2p/go-libp2p-quic-transport/listener.go:69:24: cannot use err (type error) as type string in argument to sess.CloseWithError
 ../../libp2p/go-libp2p-quic-transport/transport.go:27:2: unknown field 'AcceptCookie' in struct literal of type quic.Config
```