### PR TITLE
resolve unspecified addresses

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -44,7 +44,7 @@ func newListener(addr ma.Multiaddr, transport tpt.Transport, localPeer peer.ID, 
 	if err != nil {
 		return nil, err
 	}
-	localMultiaddr, err := toQuicMultiaddr(ln.Addr())
+	localMultiaddr, err := toQuicMultiaddrLocal(ln.Addr())
 	if err != nil {
 		return nil, err
 	}

--- a/quic_multiaddr.go
+++ b/quic_multiaddr.go
@@ -1,8 +1,10 @@
 package libp2pquic
 
 import (
+	"errors"
 	"net"
 
+	addrutil "github.com/libp2p/go-addr-util"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 )
@@ -27,4 +29,22 @@ func toQuicMultiaddr(na net.Addr) (ma.Multiaddr, error) {
 
 func fromQuicMultiaddr(addr ma.Multiaddr) (net.Addr, error) {
 	return manet.ToNetAddr(addr.Decapsulate(quicMA))
+}
+
+// this is a bit hacky, but it fixes a problem with "unspecified addresses" (0.0.0.0)
+// appearing in connections. (this breaks libp2p and ipfs assumptions -- listeners
+// may have unspecified addrs, but connections should not -- should use loopback ip).
+func toQuicMultiaddrLocal(na net.Addr) (ma.Multiaddr, error) {
+	qma, err := toQuicMultiaddr(na)
+	if err != nil {
+		return nil, err
+	}
+	rma, err := addrutil.ResolveUnspecifiedAddresses([]ma.Multiaddr{qma}, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(rma) < 1 {
+		return nil, errors.New("failed to resolve multiaddr")
+	}
+	return rma[0], nil
 }

--- a/transport.go
+++ b/transport.go
@@ -141,7 +141,7 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 	if err != nil {
 		return nil, err
 	}
-	localMultiaddr, err := toQuicMultiaddr(sess.LocalAddr())
+	localMultiaddr, err := toQuicMultiaddrLocal(sess.LocalAddr())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
this fixes a tricky bug i found while trying to connect quic nodes
to each other in my local machine. They weren't able to connect to
each other because they weren't finding each other via the dht --
they would fail to advertise addresses to each other. (this bug
caused advertising of addrs via the identify protocol to fail).

unspecified (0.0.0.0) addresses are not meant to be part of
connections. libp2p assumes that conns have specified addresses.
0.0.0.0 addrs from listeners need to be resolved when assigned to
a connection.

Im not sure how transports like TCP achieve this (is this in manet?
default from golang/net package?), but there is a difference between
QUIC and TCP. For now, im using the addrutil function, but this is
probably not the right thing to do.