### PR TITLE
implement a garbage-collector for unused reuse connections

### DIFF
--- a/libp2pquic_suite_test.go
+++ b/libp2pquic_suite_test.go
@@ -1,7 +1,11 @@
 package libp2pquic
 
 import (
+	"bytes"
 	mrand "math/rand"
+	"runtime/pprof"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,4 +20,27 @@ func TestLibp2pQuicTransport(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	mrand.Seed(GinkgoRandomSeed())
+})
+
+var garbageCollectIntervalOrig time.Duration
+var maxUnusedDurationOrig time.Duration
+
+func isGarbageCollectorRunning() bool {
+	var b bytes.Buffer
+	pprof.Lookup("goroutine").WriteTo(&b, 1)
+	return strings.Contains(b.String(), "go-libp2p-quic-transport.(*reuse).runGarbageCollector")
+}
+
+var _ = BeforeEach(func() {
+	Expect(isGarbageCollectorRunning()).To(BeFalse())
+	garbageCollectIntervalOrig = garbageCollectInterval
+	maxUnusedDurationOrig = maxUnusedDuration
+	garbageCollectInterval = 50 * time.Millisecond
+	maxUnusedDuration = 0
+})
+
+var _ = AfterEach(func() {
+	Eventually(isGarbageCollectorRunning).Should(BeFalse())
+	garbageCollectInterval = garbageCollectIntervalOrig
+	maxUnusedDuration = maxUnusedDurationOrig
 })

--- a/listener.go
+++ b/listener.go
@@ -101,7 +101,7 @@ func (l *listener) setupConn(sess quic.Session) (tpt.CapableConn, error) {
 
 // Close closes the listener.
 func (l *listener) Close() error {
-	l.conn.DecreaseCount()
+	defer l.conn.DecreaseCount()
 	return l.quicListener.Close()
 }
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Listener", func() {
 			Expect(err).ToNot(HaveOccurred())
 			ln, err := t.Listen(localAddr)
 			Expect(err).ToNot(HaveOccurred())
+			defer ln.Close()
 			netAddr := ln.Addr()
 			Expect(netAddr).To(BeAssignableToTypeOf(&net.UDPAddr{}))
 			port := netAddr.(*net.UDPAddr).Port
@@ -45,6 +46,7 @@ var _ = Describe("Listener", func() {
 			Expect(err).ToNot(HaveOccurred())
 			ln, err := t.Listen(localAddr)
 			Expect(err).ToNot(HaveOccurred())
+			defer ln.Close()
 			netAddr := ln.Addr()
 			Expect(netAddr).To(BeAssignableToTypeOf(&net.UDPAddr{}))
 			port := netAddr.(*net.UDPAddr).Port
@@ -57,6 +59,7 @@ var _ = Describe("Listener", func() {
 			Expect(err).ToNot(HaveOccurred())
 			ln, err := t.Listen(localAddr)
 			Expect(err).ToNot(HaveOccurred())
+			defer ln.Close()
 			netAddr := ln.Addr()
 			Expect(netAddr).To(BeAssignableToTypeOf(&net.UDPAddr{}))
 			port := netAddr.(*net.UDPAddr).Port

--- a/reuse.go
+++ b/reuse.go
@@ -132,20 +132,20 @@ func (r *reuse) Listen(network string, laddr *net.UDPAddr) (*reuseConn, error) {
 	defer r.mutex.Unlock()
 
 	// Deal with listen on a global address
-	if laddr.IP.IsUnspecified() {
+	if localAddr.IP.IsUnspecified() {
 		// The kernel already checked that the laddr is not already listen
 		// so we need not check here (when we create ListenUDP).
-		r.global[laddr.Port] = rconn
+		r.global[localAddr.Port] = rconn
 		return rconn, err
 	}
 
 	// Deal with listen on a unicast address
 	if _, ok := r.unicast[localAddr.IP.String()]; !ok {
-		r.unicast[laddr.IP.String()] = make(map[int]*reuseConn)
+		r.unicast[localAddr.IP.String()] = make(map[int]*reuseConn)
 	}
 
 	// The kernel already checked that the laddr is not already listen
 	// so we need not check here (when we create ListenUDP).
-	r.unicast[laddr.IP.String()][localAddr.Port] = rconn
+	r.unicast[localAddr.IP.String()][localAddr.Port] = rconn
 	return rconn, err
 }

--- a/reuse.go
+++ b/reuse.go
@@ -84,12 +84,14 @@ func (r *reuse) runGarbageCollector() {
 		r.mutex.Lock()
 		for key, conn := range r.global {
 			if conn.ShouldGarbageCollect(now) {
+				conn.Close()
 				delete(r.global, key)
 			}
 		}
 		for ukey, conns := range r.unicast {
 			for key, conn := range conns {
 				if conn.ShouldGarbageCollect(now) {
+					conn.Close()
 					delete(conns, key)
 				}
 			}

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -3,10 +3,17 @@ package libp2pquic
 import (
 	"net"
 	"runtime"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func (c *reuseConn) GetCount() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.refCount
+}
 
 var _ = Describe("Reuse", func() {
 	var reuse *reuse
@@ -17,65 +24,136 @@ var _ = Describe("Reuse", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("creates a new global connection when listening on 0.0.0.0", func() {
-		addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
-		Expect(err).ToNot(HaveOccurred())
-		conn, err := reuse.Listen("udp4", addr)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(conn.GetCount()).To(Equal(1))
-	})
+	Context("creating and reusing connections", func() {
+		AfterEach(func() {
+			reuse.mutex.Lock()
+			for _, conn := range reuse.global {
+				for conn.GetCount() > 0 {
+					conn.DecreaseCount()
+				}
+			}
+			for _, conns := range reuse.unicast {
+				for _, conn := range conns {
+					for conn.GetCount() > 0 {
+						conn.DecreaseCount()
+					}
+				}
+			}
+			reuse.mutex.Unlock()
+			Eventually(isGarbageCollectorRunning).Should(BeFalse())
+		})
 
-	It("creates a new global connection when listening on [::]", func() {
-		addr, err := net.ResolveUDPAddr("udp6", "[::]:1234")
-		Expect(err).ToNot(HaveOccurred())
-		conn, err := reuse.Listen("udp6", addr)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(conn.GetCount()).To(Equal(1))
-	})
-
-	It("creates a new global connection when dialing", func() {
-		addr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
-		Expect(err).ToNot(HaveOccurred())
-		conn, err := reuse.Dial("udp4", addr)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(conn.GetCount()).To(Equal(1))
-		laddr := conn.LocalAddr().(*net.UDPAddr)
-		Expect(laddr.IP.String()).To(Equal("0.0.0.0"))
-		Expect(laddr.Port).ToNot(BeZero())
-	})
-
-	It("reuses a connection it created for listening when dialing", func() {
-		// listen
-		addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
-		Expect(err).ToNot(HaveOccurred())
-		lconn, err := reuse.Listen("udp4", addr)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(lconn.GetCount()).To(Equal(1))
-		// dial
-		raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
-		Expect(err).ToNot(HaveOccurred())
-		conn, err := reuse.Dial("udp4", raddr)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(conn.GetCount()).To(Equal(2))
-	})
-
-	if runtime.GOOS == "linux" {
-		It("reuses a connection it created for listening on a specific interface", func() {
-			raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
+		It("creates a new global connection when listening on 0.0.0.0", func() {
+			addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
 			Expect(err).ToNot(HaveOccurred())
-			ips, err := reuse.getSourceIPs("udp4", raddr)
+			conn, err := reuse.Listen("udp4", addr)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ips).ToNot(BeEmpty())
+			Expect(conn.GetCount()).To(Equal(1))
+		})
+
+		It("creates a new global connection when listening on [::]", func() {
+			addr, err := net.ResolveUDPAddr("udp6", "[::]:1234")
+			Expect(err).ToNot(HaveOccurred())
+			conn, err := reuse.Listen("udp6", addr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conn.GetCount()).To(Equal(1))
+		})
+
+		It("creates a new global connection when dialing", func() {
+			addr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
+			Expect(err).ToNot(HaveOccurred())
+			conn, err := reuse.Dial("udp4", addr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conn.GetCount()).To(Equal(1))
+			laddr := conn.LocalAddr().(*net.UDPAddr)
+			Expect(laddr.IP.String()).To(Equal("0.0.0.0"))
+			Expect(laddr.Port).ToNot(BeZero())
+		})
+
+		It("reuses a connection it created for listening when dialing", func() {
 			// listen
-			addr, err := net.ResolveUDPAddr("udp4", ips[0].String()+":0")
+			addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
 			Expect(err).ToNot(HaveOccurred())
 			lconn, err := reuse.Listen("udp4", addr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(lconn.GetCount()).To(Equal(1))
 			// dial
+			raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
+			Expect(err).ToNot(HaveOccurred())
 			conn, err := reuse.Dial("udp4", raddr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn.GetCount()).To(Equal(2))
 		})
-	}
+
+		if runtime.GOOS == "linux" {
+			It("reuses a connection it created for listening on a specific interface", func() {
+				raddr, err := net.ResolveUDPAddr("udp4", "1.1.1.1:1234")
+				Expect(err).ToNot(HaveOccurred())
+				ips, err := reuse.getSourceIPs("udp4", raddr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ips).ToNot(BeEmpty())
+				// listen
+				addr, err := net.ResolveUDPAddr("udp4", ips[0].String()+":0")
+				Expect(err).ToNot(HaveOccurred())
+				lconn, err := reuse.Listen("udp4", addr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(lconn.GetCount()).To(Equal(1))
+				// dial
+				conn, err := reuse.Dial("udp4", raddr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(conn.GetCount()).To(Equal(2))
+			})
+		}
+	})
+
+	Context("garbage-collecting connections", func() {
+		numGlobals := func() int {
+			reuse.mutex.Lock()
+			defer reuse.mutex.Unlock()
+			return len(reuse.global)
+		}
+
+		BeforeEach(func() {
+			maxUnusedDuration = 100 * time.Millisecond
+		})
+
+		It("garbage collects connections once they're not used any more for a certain time", func() {
+			addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
+			Expect(err).ToNot(HaveOccurred())
+			lconn, err := reuse.Listen("udp4", addr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(lconn.GetCount()).To(Equal(1))
+
+			closeTime := time.Now()
+			lconn.DecreaseCount()
+
+			for {
+				num := numGlobals()
+				if closeTime.Add(maxUnusedDuration).Before(time.Now()) {
+					break
+				}
+				Expect(num).To(Equal(1))
+				time.Sleep(2 * time.Millisecond)
+			}
+			Eventually(numGlobals).Should(BeZero())
+		})
+
+		It("only stops the garbage collector when there are no more connections", func() {
+			addr1, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
+			Expect(err).ToNot(HaveOccurred())
+			conn1, err := reuse.Listen("udp4", addr1)
+			Expect(err).ToNot(HaveOccurred())
+
+			addr2, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
+			Expect(err).ToNot(HaveOccurred())
+			conn2, err := reuse.Listen("udp4", addr2)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(isGarbageCollectorRunning).Should(BeTrue())
+			conn1.DecreaseCount()
+			Consistently(isGarbageCollectorRunning, 2*maxUnusedDuration).Should(BeTrue())
+			conn2.DecreaseCount()
+			Eventually(isGarbageCollectorRunning, 2*maxUnusedDuration).Should(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
Fixes #70.

This PR implements the sweeper as suggested in #63.

The sweeper runs every 30 seconds and removes connections that have been unused for more than 10 seconds. In order to not leak go routines, it stops itself once a `reuse` doesn't have any more active connections, and is restarted as soon as a connection is added.

