### PR TITLE
Use specific netlink families for android

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f // indirect
 	github.com/whyrusleeping/mafmt v1.2.8
+	golang.org/x/sys v0.0.0-20190526052359-791d8a0f4d09
 )

--- a/netlink_android.go
+++ b/netlink_android.go
@@ -1,8 +1,0 @@
-// +build android
-
-package libp2pquic
-
-import "golang.org/x/sys/unix"
-
-// Android doesn't allow netlink_xfrm and netlink_netfilter in his base policy
-var SupportedNlFamilies = []int{unix.NETLINK_ROUTE}

--- a/netlink_android.go
+++ b/netlink_android.go
@@ -1,0 +1,8 @@
+// +build android
+
+package libp2pquic
+
+import "golang.org/x/sys/unix"
+
+// Android doesn't allow netlink_xfrm and netlink_netfilter in his base policy
+var SupportedNlFamilies = []int{unix.NETLINK_ROUTE}

--- a/netlink_linux.go
+++ b/netlink_linux.go
@@ -1,0 +1,10 @@
+// +build linux
+
+package libp2pquic
+
+import "golang.org/x/sys/unix"
+
+// We just need netlink_route here.
+// note: We should avoid the use of netlink_xfrm or netlink_netfilter has it is
+// not allowed by Android in his base policy.
+var SupportedNlFamilies = []int{unix.NETLINK_ROUTE}

--- a/netlink_other.go
+++ b/netlink_other.go
@@ -1,4 +1,4 @@
-// +build !android
+// +build !linux
 
 package libp2pquic
 

--- a/netlink_other.go
+++ b/netlink_other.go
@@ -1,0 +1,8 @@
+// +build !android
+
+package libp2pquic
+
+import "github.com/vishvananda/netlink/nl"
+
+// nl.SupportedNlFamilies is the default netlink families used by the netlink package
+var SupportedNlFamilies = nl.SupportedNlFamilies

--- a/reuse.go
+++ b/reuse.go
@@ -62,7 +62,7 @@ type reuse struct {
 
 func newReuse() (*reuse, error) {
 	// On non-Linux systems, this will return ErrNotImplemented.
-	handle, err := netlink.NewHandle()
+	handle, err := netlink.NewHandle(SupportedNlFamilies...)
 	if err == netlink.ErrNotImplemented {
 		handle = nil
 	} else if err != nil {


### PR DESCRIPTION
Hi there !

I work at Berty and actually use this lib along with libp2p on mobile.
Since a recent change and more particularly since the introduction of netlink for the reuse port, we can't use this lib anymore on Android.

Android doesn't allow netlink_xfrm & netlink_nflog in his base policy in enforce mode (see [here](https://android.googlesource.com/platform/system/sepolicy/+/3aa1c1725ea2b6fd452c5771629dcfc50a351538/public/app.te#396)).
this cause a _permission denied_ when NewTransport method is called on android:

```
type=1400 audit(0.0:98079): avc: denied { create } for scontext=u:r:untrusted_app:s0:c182,c256,c512,c768 tcontext=u:r:untrusted_app:s0:c182,c256,c512,c768 tclass=netlink_xfrm_socket permissive=0
```

However it's look like that only *netlink route* is needed, so we tried to limit netlink
families support on android build to NETLINK_ROUTE only when netlink.NewHandle is called, it seems good enough in our case and don’t cause any error anymore! 😄 

I know you have no need to support android, but this change should not impact you since it will only build on android. Also, to be honnest, i'm not sure I understand all the implication of this change, it’s maybe not the good way to go, I’d like your advice on the subject.