### PR TITLE
add support for multiaddr filtering

### DIFF
--- a/filtered_conn.go
+++ b/filtered_conn.go
@@ -1,0 +1,34 @@
+package libp2pquic
+
+import (
+	"net"
+
+	filter "github.com/libp2p/go-maddr-filter"
+)
+
+type filteredConn struct {
+	net.PacketConn
+
+	filters *filter.Filters
+}
+
+func newFilteredConn(c net.PacketConn, filters *filter.Filters) net.PacketConn {
+	return &filteredConn{PacketConn: c, filters: filters}
+}
+
+func (c *filteredConn) ReadFrom(b []byte) (n int, addr net.Addr, rerr error) {
+	for {
+		n, addr, rerr = c.PacketConn.ReadFrom(b)
+		// Short Header packet, see https://tools.ietf.org/html/draft-ietf-quic-invariants-07#section-4.2.
+		if n < 1 || b[0]&0x80 == 0 {
+			return
+		}
+		maddr, err := toQuicMultiaddr(addr)
+		if err != nil {
+			panic(err)
+		}
+		if !c.filters.AddrBlocked(maddr) {
+			return
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ipfs/go-log v1.0.2
 	github.com/libp2p/go-libp2p-core v0.5.0
 	github.com/libp2p/go-libp2p-tls v0.1.3
+	github.com/libp2p/go-maddr-filter v0.0.5
 	github.com/lucas-clemente/quic-go v0.15.2
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/libp2p/go-libp2p-core v0.5.0 h1:FBQ1fpq2Fo/ClyjojVJ5AKXlKhvNc/B6U0O+7
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-tls v0.1.3 h1:twKMhMu44jQO+HgQK9X8NHO5HkeJu2QbhLzLJpa8oNM=
 github.com/libp2p/go-libp2p-tls v0.1.3/go.mod h1:wZfuewxOndz5RTnCAxFliGjvYSDA40sKitV4c50uI1M=
+github.com/libp2p/go-maddr-filter v0.0.5 h1:CW3AgbMO6vUvT4kf87y4N+0P8KUl2aqLYhrGyDUbLSg=
+github.com/libp2p/go-maddr-filter v0.0.5/go.mod h1:Jk+36PMfIqCJhAnaASRH83bdAvfDRp/w6ENFaC9bG+M=
 github.com/libp2p/go-openssl v0.0.4 h1:d27YZvLoTyMhIN4njrkr8zMDOM4lfpHIp6A+TK9fovg=
 github.com/libp2p/go-openssl v0.0.4/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/lucas-clemente/quic-go v0.15.2 h1:RgxRJ7rPde0Q/uXDeb3/UdblVvxrYGDAG9G9GO78LmI=
@@ -166,6 +168,7 @@ github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjW
 github.com/multiformats/go-base32 v0.0.3 h1:tw5+NhuwaOjJCC5Pp82QuXbrmLzWg7uxlMFp8Nq/kkI=
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=
+github.com/multiformats/go-multiaddr v0.0.1/go.mod h1:xKVEak1K9cS1VdmPZW3LSIb6lgmoS58qz/pzqmAxV44=
 github.com/multiformats/go-multiaddr v0.0.2/go.mod h1:xKVEak1K9cS1VdmPZW3LSIb6lgmoS58qz/pzqmAxV44=
 github.com/multiformats/go-multiaddr v0.1.1 h1:rVAztJYMhCQ7vEFr8FvxW3mS+HF2eY/oPbOMeS0ZDnE=
 github.com/multiformats/go-multiaddr v0.1.1/go.mod h1:aMKBKNEYmzmDmxfX88/vz+J5IU55txyt0p4aiWVohjo=

--- a/libp2pquic_suite_test.go
+++ b/libp2pquic_suite_test.go
@@ -5,12 +5,13 @@ import (
 	mrand "math/rand"
 	"runtime/pprof"
 	"strings"
+	"testing"
 	"time"
+
+	"github.com/lucas-clemente/quic-go"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestLibp2pQuicTransport(t *testing.T) {
@@ -22,8 +23,11 @@ var _ = BeforeSuite(func() {
 	mrand.Seed(GinkgoRandomSeed())
 })
 
-var garbageCollectIntervalOrig time.Duration
-var maxUnusedDurationOrig time.Duration
+var (
+	garbageCollectIntervalOrig time.Duration
+	maxUnusedDurationOrig      time.Duration
+	origQuicConfig             *quic.Config
+)
 
 func isGarbageCollectorRunning() bool {
 	var b bytes.Buffer
@@ -37,10 +41,13 @@ var _ = BeforeEach(func() {
 	maxUnusedDurationOrig = maxUnusedDuration
 	garbageCollectInterval = 50 * time.Millisecond
 	maxUnusedDuration = 0
+	origQuicConfig = quicConfig
+	quicConfig = quicConfig.Clone()
 })
 
 var _ = AfterEach(func() {
 	Eventually(isGarbageCollectorRunning).Should(BeFalse())
 	garbageCollectInterval = garbageCollectIntervalOrig
 	maxUnusedDuration = maxUnusedDurationOrig
+	quicConfig = origQuicConfig
 })

--- a/listener_test.go
+++ b/listener_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Listener", func() {
 		Expect(err).ToNot(HaveOccurred())
 		key, err := ic.UnmarshalRsaPrivateKey(x509.MarshalPKCS1PrivateKey(rsaKey))
 		Expect(err).ToNot(HaveOccurred())
-		t, err = NewTransport(key, nil)
+		t, err = NewTransport(key, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/reuse_linux_test.go
+++ b/reuse_linux_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Reuse (on Linux)", func() {
 
 	BeforeEach(func() {
 		var err error
-		reuse, err = newReuse()
+		reuse, err = newReuse(nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/reuse_not_win.go
+++ b/reuse_not_win.go
@@ -5,6 +5,8 @@ package libp2pquic
 import (
 	"net"
 
+	filter "github.com/libp2p/go-maddr-filter"
+
 	"github.com/vishvananda/netlink"
 )
 
@@ -14,7 +16,7 @@ type reuse struct {
 	handle *netlink.Handle // Only set on Linux. nil on other systems.
 }
 
-func newReuse() (*reuse, error) {
+func newReuse(filters *filter.Filters) (*reuse, error) {
 	handle, err := netlink.NewHandle(SupportedNlFamilies...)
 	if err == netlink.ErrNotImplemented {
 		handle = nil
@@ -22,7 +24,7 @@ func newReuse() (*reuse, error) {
 		return nil, err
 	}
 	return &reuse{
-		reuseBase: newReuseBase(),
+		reuseBase: newReuseBase(filters),
 		handle:    handle,
 	}, nil
 }

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Reuse", func() {
 
 	BeforeEach(func() {
 		var err error
-		reuse, err = newReuse()
+		reuse, err = newReuse(nil)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/reuse_win.go
+++ b/reuse_win.go
@@ -2,14 +2,18 @@
 
 package libp2pquic
 
-import "net"
+import (
+	"net"
+
+	filter "github.com/libp2p/go-maddr-filter"
+)
 
 type reuse struct {
 	reuseBase
 }
 
-func newReuse() (*reuse, error) {
-	return &reuse{reuseBase: newReuseBase()}, nil
+func newReuse(filters *filter.Filters) (*reuse, error) {
+	return &reuse{reuseBase: newReuseBase(filters)}, nil
 }
 
 func (r *reuse) Dial(network string, raddr *net.UDPAddr) (*reuseConn, error) {

--- a/transport.go
+++ b/transport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/pnet"
 	tpt "github.com/libp2p/go-libp2p-core/transport"
 	p2ptls "github.com/libp2p/go-libp2p-tls"
+	filter "github.com/libp2p/go-maddr-filter"
 	quic "github.com/lucas-clemente/quic-go"
 	ma "github.com/multiformats/go-multiaddr"
 	mafmt "github.com/multiformats/go-multiaddr-fmt"
@@ -36,12 +37,12 @@ type connManager struct {
 	reuseUDP6 *reuse
 }
 
-func newConnManager() (*connManager, error) {
-	reuseUDP4, err := newReuse()
+func newConnManager(filters *filter.Filters) (*connManager, error) {
+	reuseUDP4, err := newReuse(filters)
 	if err != nil {
 		return nil, err
 	}
-	reuseUDP6, err := newReuse()
+	reuseUDP6, err := newReuse(filters)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ type transport struct {
 var _ tpt.Transport = &transport{}
 
 // NewTransport creates a new QUIC transport
-func NewTransport(key ic.PrivKey, psk pnet.PSK) (tpt.Transport, error) {
+func NewTransport(key ic.PrivKey, psk pnet.PSK, filters *filter.Filters) (tpt.Transport, error) {
 	if len(psk) > 0 {
 		log.Error("QUIC doesn't support private networks yet.")
 		return nil, errors.New("QUIC doesn't support private networks yet")
@@ -102,7 +103,7 @@ func NewTransport(key ic.PrivKey, psk pnet.PSK) (tpt.Transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	connManager, err := newConnManager()
+	connManager, err := newConnManager(filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #124.

When multiplexing incoming and outgoing connections on the same packet conn, quic-go expects the packet conns to be the same struct. Therefore, filters are applied for incoming and outgoing connections.