### PR TITLE
close the connection when it is refused by InterceptSecured

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -49,7 +49,7 @@ func (c *mockGater) InterceptAddrDial(peer.ID, ma.Multiaddr) (allow bool) {
 func (c *mockGater) InterceptSecured(_ network.Direction, p peer.ID, _ network.ConnMultiaddrs) (allow bool) {
 	c.lk.Lock()
 	defer c.lk.Unlock()
-	return !(p == c.blockedPeer)
+	return p != c.blockedPeer
 }
 
 func (c *mockGater) InterceptUpgraded(network.Conn) (allow bool, reason control.DisconnectReason) {

--- a/transport.go
+++ b/transport.go
@@ -180,13 +180,13 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 
 	localMultiaddr, err := toQuicMultiaddr(pconn.LocalAddr())
 	if err != nil {
-		pconn.DecreaseCount()
+		sess.CloseWithError(0, "")
 		return nil, err
 	}
 
 	connaddrs := &connAddrs{lmAddr: localMultiaddr, rmAddr: remoteMultiaddr}
 	if t.gater != nil && !t.gater.InterceptSecured(n.DirOutbound, p, connaddrs) {
-		pconn.DecreaseCount()
+		sess.CloseWithError(0, "")
 		return nil, fmt.Errorf("secured connection gated")
 	}
 


### PR DESCRIPTION
Minimally fixes #155. Closes #156.

This is the solution to #155 that's analogous to what we do for other transports: We first finish the cryptographic handshake (which verifies the peer's identity), and then afterwards close the connection when the connection gater doesn't like that peer's ID.