### PR TITLE
Revert "fix a potential nil-pointer panic."

### DIFF
--- a/filtered_conn.go
+++ b/filtered_conn.go
@@ -51,7 +51,7 @@ func (c *filteredConn) ReadFrom(b []byte) (n int, addr net.Addr, rerr error) {
 
 		connAddrs := &connAddrs{lmAddr: c.lmAddr, rmAddr: rmAddr}
 
-		if c.gater != nil && c.gater.InterceptAccept(connAddrs) {
+		if c.gater.InterceptAccept(connAddrs) {
 			return
 		}
 	}


### PR DESCRIPTION
Reverts libp2p/go-libp2p-quic-transport#158. Not necessary as the `filteredConn` is only created when a gater exists.