### PR TITLE
switch from gzip to zstd for qlog compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/golang/mock v1.4.4
 	github.com/ipfs/go-log v1.0.4
+	github.com/klauspost/compress v1.11.7
 	github.com/libp2p/go-libp2p-core v0.8.0
 	github.com/libp2p/go-libp2p-tls v0.1.3
 	github.com/libp2p/go-netroute v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
+github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -2,10 +2,11 @@ package libp2pquic
 
 import (
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/lucas-clemente/quic-go/logging"
 
@@ -43,12 +44,12 @@ var _ = Describe("qlogger", func() {
 		logger := newQlogger(qlogDir, logging.PerspectiveServer, []byte{0xde, 0xad, 0xbe, 0xef})
 		file := getFile()
 		Expect(string(file.Name()[0])).To(Equal("."))
-		Expect(file.Name()).To(HaveSuffix(".qlog.gz.swp"))
+		Expect(file.Name()).To(HaveSuffix(".qlog.zst.swp"))
 		// close the logger. This should move the file.
 		Expect(logger.Close()).To(Succeed())
 		file = getFile()
 		Expect(string(file.Name()[0])).ToNot(Equal("."))
-		Expect(file.Name()).To(HaveSuffix(".qlog.gz"))
+		Expect(file.Name()).To(HaveSuffix(".qlog.zst"))
 		Expect(file.Name()).To(And(
 			ContainSubstring("server"),
 			ContainSubstring("deadbeef"),
@@ -76,7 +77,7 @@ var _ = Describe("qlogger", func() {
 		compressed, err := ioutil.ReadFile(qlogDir + "/" + getFile().Name())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(compressed).ToNot(Equal("foobar"))
-		gz, err := gzip.NewReader(bytes.NewReader(compressed))
+		gz, err := zstd.NewReader(bytes.NewReader(compressed))
 		Expect(err).ToNot(HaveOccurred())
 		data, err := ioutil.ReadAll(gz)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
When running a high-bandwidth connection, qlogging consumes about ~40% CPU, of which 1/4 is spent on JSON encoding an 3/4 is spent on running gzip. Switching from gzip to zstd reduces the time spent on compression to 1/2 of the time spent on JSON encoding. That's a speedup of 6x.

Changing the compression level doesn't actually have a large influence on the file size (in my tests I wasn't able to gain more than 10% by increasing it), so using the fastest compression makes sense here. The zst file will be roughly as large as the gzip file.