### PR TITLE
reduce the zstd window size from 8 MB to 32 KB

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -82,7 +82,7 @@ func (l *qlogger) Close() error {
 	}
 	defer f.Close()
 	buf := bufio.NewWriter(f)
-	c, err := zstd.NewWriter(buf, zstd.WithEncoderLevel(zstd.SpeedFastest))
+	c, err := zstd.NewWriter(buf, zstd.WithEncoderLevel(zstd.SpeedFastest), zstd.WithWindowSize(32*1024))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Benchmarks using sample qlog files show that this achieves in improvement in both compression efficiency and compression speed.
More importantly, it prevents us from allocating a 8 MB every time a QUIC connection is closed.

See https://github.com/klauspost/compress/issues/316.