### PR TITLE
don't compare peer IDs when hole punching

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -377,7 +377,7 @@ var _ = Describe("Connection", func() {
 		connChan := make(chan tpt.CapableConn)
 		go func() {
 			defer GinkgoRecover()
-			conn, err := t2.Dial(n.WithSimultaneousConnect(context.Background(), ""), ln1.Multiaddr(), serverID)
+			conn, err := t2.Dial(context.Background(), ln1.Multiaddr(), serverID)
 			Expect(err).ToNot(HaveOccurred())
 			connChan <- conn
 		}()

--- a/transport.go
+++ b/transport.go
@@ -1,7 +1,6 @@
 package libp2pquic
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -179,9 +178,7 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 	tlsConf, keyCh := t.identity.ConfigForPeer(p)
 
 	if simConnect, _ := n.GetSimultaneousConnect(ctx); simConnect {
-		if bytes.Compare([]byte(t.localPeer), []byte(p)) < 0 {
-			return t.holePunch(ctx, network, addr, p)
-		}
+		return t.holePunch(ctx, network, addr, p)
 	}
 
 	pconn, err := t.connManager.Dial(network, addr)


### PR DESCRIPTION
@mxinden pointed out that comparing peer IDs when hole punching is not necessary. We'll have logic in our DCUtR protocol anyway to assign the role of client and server (we'll need the same logic to coordinate the TCP sim open).