### PR TITLE
implement a Transport.Close that waits for the reuse's GC to finish

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -20,6 +20,9 @@ jobs:
         run: go install
       - name: Run tests
         run: ginkgo -r -v --cover -coverprofile coverage.txt --randomizeAllSpecs --randomizeSuites --trace --progress
+      - name: Run tests with race detector
+        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+        run: ginkgo -r -v -race --randomizeAllSpecs --randomizeSuites --trace --progress
       - name: Run tests (32 bit)
         if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
         env:

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"io/ioutil"
 	mrand "math/rand"
 	"net"
@@ -70,11 +71,13 @@ var _ = Describe("Connection", func() {
 	It("handshakes on IPv4", func() {
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln.Close()
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
 		Expect(err).ToNot(HaveOccurred())
 		defer conn.Close()
@@ -94,11 +97,13 @@ var _ = Describe("Connection", func() {
 	It("handshakes on IPv6", func() {
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip6/::1/udp/0/quic")
 		defer ln.Close()
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
 		Expect(err).ToNot(HaveOccurred())
 		defer conn.Close()
@@ -118,11 +123,13 @@ var _ = Describe("Connection", func() {
 	It("opens and accepts streams", func() {
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln.Close()
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
 		Expect(err).ToNot(HaveOccurred())
 		defer conn.Close()
@@ -147,6 +154,7 @@ var _ = Describe("Connection", func() {
 
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
@@ -154,6 +162,7 @@ var _ = Describe("Connection", func() {
 		// dial, but expect the wrong peer ID
 		_, err = clientTransport.Dial(context.Background(), ln.Multiaddr(), thirdPartyID)
 		Expect(err).To(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		Expect(err.Error()).To(ContainSubstring("CRYPTO_ERROR"))
 
 		done := make(chan struct{})
@@ -172,6 +181,7 @@ var _ = Describe("Connection", func() {
 		cg.EXPECT().InterceptAccept(gomock.Any())
 		serverTransport, err := NewTransport(serverKey, nil, cg)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln.Close()
 
@@ -185,6 +195,7 @@ var _ = Describe("Connection", func() {
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		// make sure that connection attempts fails
 		conn, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
 		Expect(err).ToNot(HaveOccurred())
@@ -205,6 +216,7 @@ var _ = Describe("Connection", func() {
 	It("gates secured connections", func() {
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln.Close()
 
@@ -213,6 +225,7 @@ var _ = Describe("Connection", func() {
 
 		clientTransport, err := NewTransport(clientKey, nil, cg)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 
 		// make sure that connection attempts fails
 		_, err = clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
@@ -232,10 +245,12 @@ var _ = Describe("Connection", func() {
 
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln1 := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln1.Close()
 		serverTransport2, err := NewTransport(serverKey2, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport2.(io.Closer).Close()
 		ln2 := runServer(serverTransport2, "/ip4/127.0.0.1/udp/0/quic")
 		defer ln2.Close()
 
@@ -262,6 +277,7 @@ var _ = Describe("Connection", func() {
 
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		c1, err := clientTransport.Dial(context.Background(), ln1.Multiaddr(), serverID)
 		Expect(err).ToNot(HaveOccurred())
 		defer c1.Close()
@@ -291,6 +307,7 @@ var _ = Describe("Connection", func() {
 	It("sends stateless resets", func() {
 		serverTransport, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer serverTransport.(io.Closer).Close()
 		ln := runServer(serverTransport, "/ip4/127.0.0.1/udp/0/quic")
 
 		var drop uint32
@@ -307,6 +324,7 @@ var _ = Describe("Connection", func() {
 		// establish a connection
 		clientTransport, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer clientTransport.(io.Closer).Close()
 		proxyAddr, err := toQuicMultiaddr(proxy.LocalAddr())
 		Expect(err).ToNot(HaveOccurred())
 		conn, err := clientTransport.Dial(context.Background(), proxyAddr, serverID)
@@ -349,6 +367,7 @@ var _ = Describe("Connection", func() {
 	It("hole punches", func() {
 		t1, err := NewTransport(serverKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer t1.(io.Closer).Close()
 		laddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/quic")
 		Expect(err).ToNot(HaveOccurred())
 		ln1, err := t1.Listen(laddr)
@@ -364,6 +383,7 @@ var _ = Describe("Connection", func() {
 
 		t2, err := NewTransport(clientKey, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+		defer t2.(io.Closer).Close()
 		ln2, err := t2.Listen(laddr)
 		Expect(err).ToNot(HaveOccurred())
 		done2 := make(chan struct{})

--- a/libp2pquic_suite_test.go
+++ b/libp2pquic_suite_test.go
@@ -1,14 +1,11 @@
 package libp2pquic
 
 import (
-	"bytes"
 	mrand "math/rand"
-	"runtime/pprof"
-	"strings"
 	"testing"
 	"time"
 
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go"
 
 	. "github.com/onsi/ginkgo"
@@ -31,16 +28,9 @@ var (
 	mockCtrl                   *gomock.Controller
 )
 
-func isGarbageCollectorRunning() bool {
-	var b bytes.Buffer
-	pprof.Lookup("goroutine").WriteTo(&b, 1)
-	return strings.Contains(b.String(), "go-libp2p-quic-transport.(*reuse).runGarbageCollector")
-}
-
 var _ = BeforeEach(func() {
 	mockCtrl = gomock.NewController(GinkgoT())
 
-	Expect(isGarbageCollectorRunning()).To(BeFalse())
 	garbageCollectIntervalOrig = garbageCollectInterval
 	maxUnusedDurationOrig = maxUnusedDuration
 	garbageCollectInterval = 50 * time.Millisecond
@@ -52,7 +42,6 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	mockCtrl.Finish()
 
-	Eventually(isGarbageCollectorRunning).Should(BeFalse())
 	garbageCollectInterval = garbageCollectIntervalOrig
 	maxUnusedDuration = maxUnusedDurationOrig
 	quicConfig = origQuicConfig

--- a/listener_test.go
+++ b/listener_test.go
@@ -7,12 +7,13 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"syscall"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	tpt "github.com/libp2p/go-libp2p-core/transport"
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 
 	ma "github.com/multiformats/go-multiaddr"
 	. "github.com/onsi/ginkgo"
@@ -36,6 +37,10 @@ var _ = Describe("Listener", func() {
 		Expect(err).ToNot(HaveOccurred())
 		t, err = NewTransport(key, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(t.(io.Closer).Close()).To(Succeed())
 	})
 
 	It("uses a conn that can interface assert to a UDPConn for listening", func() {

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -51,14 +51,15 @@ var _ = Describe("Reuse", func() {
 	})
 
 	AfterEach(func() {
-		Expect(reuse.Close()).To(Succeed())
-	})
+		isGarbageCollectorRunning := func() bool {
+			var b bytes.Buffer
+			pprof.Lookup("goroutine").WriteTo(&b, 1)
+			return strings.Contains(b.String(), "go-libp2p-quic-transport.(*reuse).gc")
+		}
 
-	isGarbageCollectorRunning := func() bool {
-		var b bytes.Buffer
-		pprof.Lookup("goroutine").WriteTo(&b, 1)
-		return strings.Contains(b.String(), "go-libp2p-quic-transport.(*reuse).runGarbageCollector")
-	}
+		Expect(reuse.Close()).To(Succeed())
+		Expect(isGarbageCollectorRunning()).To(BeFalse())
+	})
 
 	Context("creating and reusing connections", func() {
 		AfterEach(func() { closeAllConns(reuse) })
@@ -126,54 +127,32 @@ var _ = Describe("Reuse", func() {
 		})
 	})
 
-	Context("garbage-collecting connections", func() {
+	It("garbage collects connections once they're not used any more for a certain time", func() {
 		numGlobals := func() int {
 			reuse.mutex.Lock()
 			defer reuse.mutex.Unlock()
 			return len(reuse.global)
 		}
 
-		BeforeEach(func() {
-			maxUnusedDuration = 100 * time.Millisecond
-		})
+		maxUnusedDuration = 100 * time.Millisecond
 
-		It("garbage collects connections once they're not used any more for a certain time", func() {
-			addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
-			Expect(err).ToNot(HaveOccurred())
-			lconn, err := reuse.Listen("udp4", addr)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lconn.GetCount()).To(Equal(1))
+		addr, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
+		Expect(err).ToNot(HaveOccurred())
+		lconn, err := reuse.Listen("udp4", addr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lconn.GetCount()).To(Equal(1))
 
-			closeTime := time.Now()
-			lconn.DecreaseCount()
+		closeTime := time.Now()
+		lconn.DecreaseCount()
 
-			for {
-				num := numGlobals()
-				if closeTime.Add(maxUnusedDuration).Before(time.Now()) {
-					break
-				}
-				Expect(num).To(Equal(1))
-				time.Sleep(2 * time.Millisecond)
+		for {
+			num := numGlobals()
+			if closeTime.Add(maxUnusedDuration).Before(time.Now()) {
+				break
 			}
-			Eventually(numGlobals).Should(BeZero())
-		})
-
-		It("only stops the garbage collector when there are no more connections", func() {
-			addr1, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
-			Expect(err).ToNot(HaveOccurred())
-			conn1, err := reuse.Listen("udp4", addr1)
-			Expect(err).ToNot(HaveOccurred())
-
-			addr2, err := net.ResolveUDPAddr("udp4", "0.0.0.0:0")
-			Expect(err).ToNot(HaveOccurred())
-			conn2, err := reuse.Listen("udp4", addr2)
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(isGarbageCollectorRunning).Should(BeTrue())
-			conn1.DecreaseCount()
-			Consistently(isGarbageCollectorRunning, 2*maxUnusedDuration).Should(BeTrue())
-			conn2.DecreaseCount()
-			Eventually(isGarbageCollectorRunning, 2*maxUnusedDuration).Should(BeFalse())
-		})
+			Expect(num).To(Equal(1))
+			time.Sleep(2 * time.Millisecond)
+		}
+		Eventually(numGlobals).Should(BeZero())
 	})
 })

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Reuse", func() {
 	var reuse *reuse
 
 	BeforeEach(func() {
-		reuse = newReuse(nil)
+		reuse = newReuse()
 	})
 
 	Context("creating and reusing connections", func() {

--- a/transport.go
+++ b/transport.go
@@ -93,6 +93,13 @@ func (c *connManager) Dial(network string, raddr *net.UDPAddr) (*reuseConn, erro
 	return reuse.Dial(network, raddr)
 }
 
+func (c *connManager) Close() error {
+	if err := c.reuseUDP6.Close(); err != nil {
+		return err
+	}
+	return c.reuseUDP4.Close()
+}
+
 // The Transport implements the tpt.Transport interface for QUIC connections.
 type transport struct {
 	privKey      ic.PrivKey
@@ -345,4 +352,8 @@ func (t *transport) Protocols() []int {
 
 func (t *transport) String() string {
 	return "QUIC"
+}
+
+func (t *transport) Close() error {
+	return t.connManager.Close()
 }

--- a/transport.go
+++ b/transport.go
@@ -56,9 +56,9 @@ type connManager struct {
 	reuseUDP6 *reuse
 }
 
-func newConnManager(gater connmgr.ConnectionGater) (*connManager, error) {
-	reuseUDP4 := newReuse(gater)
-	reuseUDP6 := newReuse(gater)
+func newConnManager() (*connManager, error) {
+	reuseUDP4 := newReuse()
+	reuseUDP6 := newReuse()
 
 	return &connManager{
 		reuseUDP4: reuseUDP4,
@@ -133,7 +133,7 @@ func NewTransport(key ic.PrivKey, psk pnet.PSK, gater connmgr.ConnectionGater) (
 	if err != nil {
 		return nil, err
 	}
-	connManager, err := newConnManager(gater)
+	connManager, err := newConnManager()
 	if err != nil {
 		return nil, err
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"io"
 	"net"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
@@ -28,6 +29,10 @@ var _ = Describe("Transport", func() {
 		Expect(err).ToNot(HaveOccurred())
 		t, err = NewTransport(key, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(t.(io.Closer).Close()).To(Succeed())
 	})
 
 	It("says if it can dial an address", func() {


### PR DESCRIPTION
This finally makes it possible to run tests with race detector, and therefore switch to the Unified CI Setup.

Not sure if the implementation of `Transport.Close` here is sufficient to fix #176 though.