### PR TITLE
fix staticcheck

### DIFF
--- a/integrationtests/main.go
+++ b/integrationtests/main.go
@@ -154,7 +154,7 @@ func testSingleFileTransfer(tr transport.Transport, serverKey crypto.PubKey, add
 	defer cancel()
 	c, err := tr.Dial(ctx, addr, serverPeerID)
 	if err != nil {
-		return fmt.Errorf("Dial failed: %w", err)
+		return fmt.Errorf("dial failed: %w", err)
 	}
 	defer c.Close()
 	if !c.RemotePublicKey().Equals(serverKey) {
@@ -195,7 +195,7 @@ func testMultipleFileTransfer(tr transport.Transport, serverKey crypto.PubKey, a
 	defer cancel()
 	c, err := tr.Dial(ctx, addr, serverPeerID)
 	if err != nil {
-		return fmt.Errorf("Dial failed: %w", err)
+		return fmt.Errorf("dial failed: %w", err)
 	}
 	defer c.Close()
 	if !c.RemotePublicKey().Equals(serverKey) {


### PR DESCRIPTION
I'm wondering what happened here:
![image](https://user-images.githubusercontent.com/1478487/126798043-1fbbdc62-3052-4c27-9da4-8a5acd0c7c7b.png)

1. Why did automerge trigger before even being merged to master?
2. Why did it merge although go-check was not happy?
