### PR TITLE
fix error assertions in the tracer

### DIFF
--- a/tracer_metrics.go
+++ b/tracer_metrics.go
@@ -229,25 +229,30 @@ func (m *metricsConnTracer) NegotiatedVersion(chosen quic.VersionNumber, clientV
 
 func (m *metricsConnTracer) ClosedConnection(e error) {
 	var (
-		transportErr *quic.TransportError
-		remote       bool
-		desc         string
+		applicationErr      *quic.ApplicationError
+		transportErr        *quic.TransportError
+		statelessResetErr   *quic.StatelessResetError
+		vnErr               *quic.VersionNegotiationError
+		idleTimeoutErr      *quic.IdleTimeoutError
+		handshakeTimeoutErr *quic.HandshakeTimeoutError
+		remote              bool
+		desc                string
 	)
 
 	switch {
-	case errors.Is(e, &quic.ApplicationError{}):
+	case errors.As(e, &applicationErr):
 		return
 	case errors.As(e, &transportErr):
 		remote = transportErr.Remote
 		desc = transportErr.ErrorCode.String()
-	case errors.Is(e, &quic.StatelessResetError{}):
+	case errors.As(e, &statelessResetErr):
 		remote = true
 		desc = "stateless_reset"
-	case errors.Is(e, &quic.VersionNegotiationError{}):
+	case errors.As(e, &vnErr):
 		desc = "version_negotiation"
-	case errors.Is(e, &quic.IdleTimeoutError{}):
+	case errors.As(e, &idleTimeoutErr):
 		desc = "idle_timeout"
-	case errors.Is(e, &quic.HandshakeTimeoutError{}):
+	case errors.As(e, &handshakeTimeoutErr):
 		desc = "handshake_timeout"
 	default:
 		desc = fmt.Sprintf("unknown error: %v", e)


### PR DESCRIPTION
Fixes #233.

`errors.Is` and `errors.As` still confuses me. What was happening here was that the `case` for the version negotiation errors didn't recognize a `quic.VersionNegotiationError` because... well, I don't really know.
I _assume_ it's because a `*quic.VersionNegotiationError` has (exported) fields, and `errors.Is` was looking for an exact match, not just a type match. This is what `errors.As` apparently does.
The same applies to a bunch of other error types as well.

With this PR, we should be able to properly increment the counter for version negotiation errors (and the other error types), instead of creating a new Prometheus counter for every error.