### PR TITLE
reuse the same router until we change listeners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/mock v1.6.0
+	github.com/google/gopacket v1.1.17
 	github.com/ipfs/go-log v1.0.4
 	github.com/klauspost/compress v1.11.7
 	github.com/libp2p/go-libp2p-core v0.10.0


### PR DESCRIPTION
Technically, someone can set net.ipv4.ip_nonlocal_bind=1 to bind to non-existent IP addresses, but I'm comfortable making this change and seeing if anyone complains. I highly doubt it'll have any impact.

If it doesn't work out, we have other options (e.g., catch the "invalid route" error and try again).