### PR TITLE
don't start a Go routine for every connection dialed

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -8,12 +8,13 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	tpt "github.com/libp2p/go-libp2p-core/transport"
 
-	quic "github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
 type conn struct {
 	sess      quic.Session
+	pconn     *reuseConn
 	transport tpt.Transport
 
 	localPeer      peer.ID
@@ -27,7 +28,11 @@ type conn struct {
 
 var _ tpt.CapableConn = &conn{}
 
+// Close closes the connection.
+// It must be called even if the peer closed the connection in order for
+// garbage collection to properly work in this package.
 func (c *conn) Close() error {
+	c.pconn.DecreaseCount()
 	return c.sess.CloseWithError(0, "")
 }
 

--- a/listener.go
+++ b/listener.go
@@ -102,19 +102,18 @@ func (l *listener) setupConn(sess quic.Session) (*conn, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	remotePeerID, err := peer.IDFromPublicKey(remotePubKey)
 	if err != nil {
 		return nil, err
 	}
-
 	remoteMultiaddr, err := toQuicMultiaddr(sess.RemoteAddr())
 	if err != nil {
 		return nil, err
 	}
-
+	l.conn.IncreaseCount()
 	return &conn{
 		sess:            sess,
+		pconn:           l.conn,
 		transport:       l.transport,
 		localPeer:       l.localPeer,
 		localMultiaddr:  l.localMultiaddr,

--- a/transport.go
+++ b/transport.go
@@ -207,10 +207,6 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 		pconn.DecreaseCount()
 		return nil, errors.New("go-libp2p-quic-transport BUG: expected remote pub key to be set")
 	}
-	go func() {
-		<-sess.Context().Done()
-		pconn.DecreaseCount()
-	}()
 
 	localMultiaddr, err := toQuicMultiaddr(pconn.LocalAddr())
 	if err != nil {
@@ -219,6 +215,7 @@ func (t *transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (tp
 	}
 	conn := &conn{
 		sess:            sess,
+		pconn:           pconn,
 		transport:       t,
 		privKey:         t.privKey,
 		localPeer:       t.localPeer,


### PR DESCRIPTION
In the swarm, we're calling Close for every connection before it is garbage collected. We therefore don't need to start a Go routine here just to see when a connection is closed.
We now also increment the reuse counter every time a connection is dialed. This simplifies closing the connection.